### PR TITLE
新規プレイヤーチェック処理改善 whoisコマンドの拡張  5時の定期再起動時の挙動変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>Setuden</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>Setuden</artifactId>
-    <version>0.14</version>
+    <version>0.15</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -19,12 +19,16 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>eco-plugin</id>
+            <url>https://ecolight15.github.io/mvn_rep/</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
             <groupId>jp.minecraftuser</groupId>
             <artifactId>EcoFramework</artifactId>
-            <version>0.18</version>
+            <version>0.29</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -42,7 +46,7 @@
         <dependency>
             <groupId>jp.minecraftuser</groupId>
             <artifactId>EcoMQTTServerLog</artifactId>
-            <version>0.4</version>
+            <version>0.7</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/jp/minecraftuser/setuden/command/SetmsgCommand.java
+++ b/src/main/java/jp/minecraftuser/setuden/command/SetmsgCommand.java
@@ -6,8 +6,12 @@ import jp.minecraftuser.ecoframework.CommandFrame;
 import jp.minecraftuser.setuden.db.WhoisDB;
 import jp.minecraftuser.ecoframework.Utl;
 import static jp.minecraftuser.ecoframework.Utl.sendPluginMessage;
+import static jp.minecraftuser.ecoframework.Utl.sendTagMessage;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+
+import java.util.List;
 
 /**
  * リロードコマンドクラス
@@ -43,7 +47,7 @@ public class SetmsgCommand extends CommandFrame {
     public boolean worker(CommandSender sender, String[] args) {
         if (args.length == 0) {
             ((WhoisDB)plg.getDB("whois")).updateMassage((OfflinePlayer) sender, null);
-            sendPluginMessage(plg, sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
+            SendLineMessage(sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
         } else {
             // 自分のメッセージ設定
             StringBuilder str = new StringBuilder();
@@ -54,9 +58,21 @@ public class SetmsgCommand extends CommandFrame {
                 str.append(args[i]);
             }
             ((WhoisDB)plg.getDB("whois")).updateMassage((OfflinePlayer) sender, Utl.repColor(str.toString()));
-            sendPluginMessage(plg, sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
+            SendLineMessage(sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
         }
         return true;
     }
-    
+
+    public void SendLineMessage(CommandSender sender,List<String> msg_list) {
+        boolean first = true;
+        for (String s : msg_list) {
+            if (first) {
+                sendPluginMessage(plg, sender, s);
+                first = false;
+            } else {
+                sendTagMessage(plg, sender, "", s);
+            }
+        }
+    }
+
 }

--- a/src/main/java/jp/minecraftuser/setuden/command/TestCommand.java
+++ b/src/main/java/jp/minecraftuser/setuden/command/TestCommand.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jp.minecraftuser.setuden.scheduler.ForumSchedulerEventKick;
 import jp.minecraftuser.setuden.test.DB;
 import jp.minecraftuser.setuden.test.TestMessageThread;
 import jp.minecraftuser.setuden.test.TestPayload;
@@ -545,6 +547,12 @@ public class TestCommand extends CommandFrame {
             }
         } else if (args[0].equalsIgnoreCase("plsave")) {
             Bukkit.savePlayers();
+        } else if (args[0].equalsIgnoreCase("kicksave")) {
+            if (args.length == 2) {
+                plg.getServer().dispatchCommand(plg.getServer().getConsoleSender(), "ecoadmin:lock "+args[1]);
+            } else {
+                plg.getServer().dispatchCommand(plg.getServer().getConsoleSender(), "ecoadmin:lock test");
+            }
         }
 
         return true;

--- a/src/main/java/jp/minecraftuser/setuden/command/WhoisCommand.java
+++ b/src/main/java/jp/minecraftuser/setuden/command/WhoisCommand.java
@@ -5,8 +5,12 @@ import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.CommandFrame;
 import jp.minecraftuser.setuden.db.WhoisDB;
 import static jp.minecraftuser.ecoframework.Utl.sendPluginMessage;
+import static jp.minecraftuser.ecoframework.Utl.sendTagMessage;
+
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.List;
 
 /**
  * リロードコマンドクラス
@@ -48,11 +52,22 @@ public class WhoisCommand extends CommandFrame {
                 sendPluginMessage(plg, sender, "コンソールからはプレイヤー指定無しでは実行できません");
                 return true;
             }
-            sendPluginMessage(plg, sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
+            SendLineMessage(sender, ((WhoisDB)plg.getDB("whois")).getWhois(sender.getName()));
         } else {
             // 自分以外
-            sendPluginMessage(plg, sender, ((WhoisDB)plg.getDB("whois")).getWhois(args[0]));
+            SendLineMessage(sender, ((WhoisDB)plg.getDB("whois")).getWhois(args[0]));
         }
         return true;
+    }
+    public void SendLineMessage(CommandSender sender,List<String> msg_list) {
+        boolean first = true;
+        for (String s : msg_list) {
+            if (first) {
+                sendPluginMessage(plg, sender, s);
+                first = false;
+            } else {
+                sendTagMessage(plg, sender, "", s);
+            }
+        }
     }
 }

--- a/src/main/java/jp/minecraftuser/setuden/db/WhoisDB.java
+++ b/src/main/java/jp/minecraftuser/setuden/db/WhoisDB.java
@@ -6,34 +6,43 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.DatabaseFrame;
 import jp.minecraftuser.ecomqttserverlog.EcoMQTTServerLog;
+import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.Statistic;
 
 /**
- *
  * @author ecolight
  */
-public class WhoisDB extends DatabaseFrame{
-    
+public class WhoisDB extends DatabaseFrame {
+
     /**
      * コンストラクタ
+     *
      * @param plg_ プラグインインスタンス
      * @param name_ 名前
      * @throws java.lang.ClassNotFoundException
      * @throws java.sql.SQLException
      */
+    String total_play_time_format = new String("%d日%02d時間%02d分%02d秒");
+
     public WhoisDB(PluginFrame plg_, String name_) throws ClassNotFoundException, SQLException {
         super(plg_, "whois.db", name_);
     }
+
     /**
      * データベース移行処理
      * 内部処理からトランザクション開始済みの状態で呼ばれる
+     *
      * @throws SQLException
      */
     @Override
@@ -61,11 +70,12 @@ public class WhoisDB extends DatabaseFrame{
                 // データベースバージョンは次版にする
                 //-----------------------------------------------------------------------------------
                 updateSettingsVersion(con);
-                
+
                 log.info(plg.getName() + " database migration " + name + " version 1 -> 2 completed.");
             }
         }
     }
+
     public boolean isExist(UUID uuid) {
         boolean exist = false;
         PreparedStatement prep = null;
@@ -85,39 +95,60 @@ public class WhoisDB extends DatabaseFrame{
             log.info(ex.getLocalizedMessage());
             log.info(ex.getMessage());
             log.info(ex.getSQLState());
-            if (rs != null) try { rs.close(); } catch (SQLException ex1) {
-                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-            if (prep != null) try { prep.close(); } catch (SQLException ex1) {
-                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-            if (con != null) try { con.close(); } catch (SQLException ex1) {
-                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
+            if (rs != null) try {
+                rs.close();
+            } catch (SQLException ex1) {
+                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+            }
+            if (prep != null) try {
+                prep.close();
+            } catch (SQLException ex1) {
+                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+            }
+            if (con != null) try {
+                con.close();
+            } catch (SQLException ex1) {
+                Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+            }
         }
 
         return exist;
     }
-    public String getWhois(String name) {
+
+    public List<String> getWhois(String name) {
         // UUID問い合わせプラグインの検出
         EcoMQTTServerLog logp = (EcoMQTTServerLog) plg.getServer().getPluginManager().getPlugin("EcoMQTTServerLog");
+        List<String> whoisTextList = new ArrayList<>();
         if (logp != null) {
             UUID uuid = logp.latestUUID(name);
             OfflinePlayer pl = plg.getServer().getOfflinePlayer(uuid);
             if (pl.isBanned()) {
-                return "Whois["+name+"] *** Banned Player *** "+getWhois(uuid);
+                whoisTextList.add("Whois[" + name + "] *** Banned Player *** ");
+                whoisTextList.addAll(getWhoisDate(uuid));
+                return whoisTextList;
             } else {
-                return "Whois["+name+"] "+getWhois(uuid);
+                whoisTextList.add("Whois[" + name + "]");
+                whoisTextList.addAll(getWhoisDate(uuid));
+                return whoisTextList;
             }
         } else {
-            return "UUID Plugin Not Ready.";
-        }            
-        
+            whoisTextList.add("Whois[" + name + "]");
+            whoisTextList.addAll(getWhoisDate(plg.getServer().getOfflinePlayer(name).getUniqueId()));
+            return whoisTextList;
+            //return "UUID Plugin Not Ready.";
+        }
+
     }
-    public String getWhois(UUID uuid) {
+
+    private List<String> getWhoisDate(UUID uuid) {
         PreparedStatement prep = null;
         ResultSet rs = null;
         String msg = null;
         Date login = null;
         Date quit = null;
         Connection con = null;
+        OfflinePlayer player = plg.getServer().getOfflinePlayer(uuid);
+        List<String> whoisTextList = new ArrayList<>();
         if (uuid != null) {
             try {
                 con = connect();
@@ -138,34 +169,67 @@ public class WhoisDB extends DatabaseFrame{
                 log.info(ex.getLocalizedMessage());
                 log.info(ex.getMessage());
                 log.info(ex.getSQLState());
-                if (rs != null) try { rs.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                if (prep != null) try { prep.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                if (con != null) try { con.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                return "database read error.";
+                if (rs != null) try {
+                    rs.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                if (prep != null) try {
+                    prep.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                if (con != null) try {
+                    con.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                whoisTextList.add("database read error.");
+                return whoisTextList;
+
             }
         }
+
+
         SimpleDateFormat sdf1 = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss ");
-        StringBuilder b = new StringBuilder("");
-        b.append("LastLogin:");
+
         if ((login == null) || (login.getTime() == 0)) {
-            b.append("No record. ");
+            whoisTextList.add("最終ログイン　:" + ChatColor.GOLD + "No record.");
         } else {
-            b.append(sdf1.format(login));
+            whoisTextList.add("最終ログイン　:" + ChatColor.GOLD + sdf1.format(login));
         }
-        b.append("LastQuit:");
         if ((quit == null) || (quit.getTime() == 0)) {
-            b.append("No record. ");
+            whoisTextList.add("最終ログアウト:" + ChatColor.GOLD + "No record.");
         } else {
-            b.append(sdf1.format(quit));
+            whoisTextList.add("最終ログアウト:" + ChatColor.GOLD + sdf1.format(quit));
         }
+
+        if (player.getFirstPlayed() == 0) {
+            whoisTextList.add("初回ログイン　:" + ChatColor.GOLD + "No record.");
+        } else {
+            Date first_login = new Date(player.getFirstPlayed());
+
+            whoisTextList.add("初回ログイン　:" + ChatColor.GOLD + sdf1.format(first_login));
+        }
+
+        if (player.getStatistic(Statistic.TOTAL_WORLD_TIME) == 0) {
+            whoisTextList.add("合計プレイ時間:" + ChatColor.GOLD + "No record.");
+        } else {
+            long total_play_second = player.getStatistic(Statistic.TOTAL_WORLD_TIME) / 20;
+            long play_day = total_play_second / 86400;
+            long play_hour = total_play_second / 3600;
+            long play_minute = (total_play_second % 3600) / 60;
+            long play_second = total_play_second % 60;
+            StringBuilder b = new StringBuilder();
+            b.append("合計プレイ時間:").append(ChatColor.GOLD).append(String.format(total_play_time_format, play_day, play_hour, play_minute, play_second));
+            whoisTextList.add(b.toString());
+        }
+
+
         if (msg != null) {
-            b.append("Message:");
-            b.append(msg);
+            whoisTextList.add("コメント　　　:" + ChatColor.GOLD + msg);
         }
-        return b.toString();
+        return whoisTextList;
     }
 
     public void update(UUID uuid, Date login, Date quit) {
@@ -192,7 +256,7 @@ public class WhoisDB extends DatabaseFrame{
                     prep.setLong(2, uuid.getMostSignificantBits());
                     prep.setLong(3, uuid.getLeastSignificantBits());
                 } else {
-                    
+
                 }
                 prep.executeUpdate();
                 con.commit();
@@ -202,10 +266,16 @@ public class WhoisDB extends DatabaseFrame{
                 log.info(ex.getLocalizedMessage());
                 log.info(ex.getMessage());
                 log.info(ex.getSQLState());
-                if (prep != null) try { prep.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                if (con != null) try { con.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
+                if (prep != null) try {
+                    prep.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                if (con != null) try {
+                    con.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
             }
         } else {
             try {
@@ -228,7 +298,7 @@ public class WhoisDB extends DatabaseFrame{
                     prep.setLong(2, uuid.getLeastSignificantBits());
                     prep.setLong(3, quit.getTime());
                 } else {
-                    
+
                 }
                 prep.executeUpdate();
                 con.commit();
@@ -238,13 +308,20 @@ public class WhoisDB extends DatabaseFrame{
                 log.info(ex.getLocalizedMessage());
                 log.info(ex.getMessage());
                 log.info(ex.getSQLState());
-                if (prep != null) try { prep.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                if (con != null) try { con.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
+                if (prep != null) try {
+                    prep.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                if (con != null) try {
+                    con.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
             }
         }
     }
+
     public void updateMassage(OfflinePlayer player, String message) {
         UUID uuid = player.getUniqueId();
         PreparedStatement prep = null;
@@ -261,15 +338,21 @@ public class WhoisDB extends DatabaseFrame{
                 con.commit();
                 prep.close();
                 con.close();
-                log.info("UpdateMessage["+player.getName()+"]:"+message);
+                log.info("UpdateMessage[" + player.getName() + "]:" + message);
             } catch (SQLException ex) {
                 log.info(ex.getLocalizedMessage());
                 log.info(ex.getMessage());
                 log.info(ex.getSQLState());
-                if (prep != null) try { prep.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
-                if (con != null) try { con.close(); } catch (SQLException ex1) {
-                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1); }
+                if (prep != null) try {
+                    prep.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
+                if (con != null) try {
+                    con.close();
+                } catch (SQLException ex1) {
+                    Logger.getLogger(WhoisDB.class.getName()).log(Level.SEVERE, null, ex1);
+                }
             }
         }
     }

--- a/src/main/java/jp/minecraftuser/setuden/listener/PlayerListener.java
+++ b/src/main/java/jp/minecraftuser/setuden/listener/PlayerListener.java
@@ -1,6 +1,6 @@
 /**
  * プレイヤー関連イベントリスナ―
- * 
+ *
  * PlayerQuit
  *   whoisログ
  * PlayerInteract
@@ -42,8 +42,10 @@ public class PlayerListener extends ListenerFrame {
      */
     public PlayerListener(PluginFrame plg_, String name_) {
         super(plg_, name_);
-        int visitor = new File(plg.getServer().getWorlds().get(0).getWorldFolder().getPath()+"/playerdata").listFiles().length;
-        prev_visitor = visitor;
+
+        //プレイヤーデータファイルの数を取得
+        prev_visitor = new File(plg.getServer().getWorld(conf.getString("level-name")).getWorldFolder().getPath()+"/playerdata").listFiles((File dir, String name) -> name.endsWith(".dat")).length;
+
     }
 
     @EventHandler(priority=EventPriority.LOWEST)
@@ -98,14 +100,12 @@ public class PlayerListener extends ListenerFrame {
         log.info("PlayerJoinEvent:" + event.getPlayer().getName());
 
         // 新規プレイヤー検出処理
-        plg.getServer().savePlayers();
-        int visitor = new File(plg.getServer().getWorld(conf.getString("level-name")).getWorldFolder().getPath()+"/playerdata").listFiles().length;
-        if (prev_visitor != visitor) {
-            plg.getServer().broadcastMessage("["+pl.getName()+"]さんは"+visitor+"人目の新規さんです。");
+        if(!pl.hasPlayedBefore()){
+            prev_visitor += 1;
+            plg.getServer().broadcastMessage("["+pl.getName()+"]さんは"+prev_visitor+"人目の新規さんです。");
         }
-        prev_visitor = visitor;
         new LoginDBTimer(plg, "logout_timer", pl, true).runTaskLaterAsynchronously(plg, 1);
-     }
+    }
 
 //    @EventHandler(priority=EventPriority.LOWEST)
 //    public void InventoryClick(InventoryClickEvent event) {

--- a/src/main/java/jp/minecraftuser/setuden/scheduler/ForumScheduler.java
+++ b/src/main/java/jp/minecraftuser/setuden/scheduler/ForumScheduler.java
@@ -110,7 +110,15 @@ public class ForumScheduler extends TimerFrame{
                     TypeDayOfWeek.SUI.getValue() |
                     TypeDayOfWeek.MOKU.getValue() |
                     TypeDayOfWeek.KIN.getValue() |
-                    TypeDayOfWeek.DO.getValue() , 5, 0, TypeEvent.SAVE);
+                    TypeDayOfWeek.DO.getValue() , 5, 0, TypeEvent.KICK, "毎日5時の定例サーバ再起動", "サーバーの定例再起動中のため一時的にログインできません");
+
+        addSchedule(TypeDayOfWeek.NICHI.getValue() |
+                TypeDayOfWeek.GETSU.getValue() |
+                TypeDayOfWeek.KA.getValue() |
+                TypeDayOfWeek.SUI.getValue() |
+                TypeDayOfWeek.MOKU.getValue() |
+                TypeDayOfWeek.KIN.getValue() |
+                TypeDayOfWeek.DO.getValue() , 5, 1, TypeEvent.SAVE);
 //        addSchedule(TypeDayOfWeek.NICHI.getValue() |
 //                    TypeDayOfWeek.GETSU.getValue() |
 //                    TypeDayOfWeek.KA.getValue() |

--- a/src/main/java/jp/minecraftuser/setuden/scheduler/ForumSchedulerEventKick.java
+++ b/src/main/java/jp/minecraftuser/setuden/scheduler/ForumSchedulerEventKick.java
@@ -4,6 +4,7 @@ package jp.minecraftuser.setuden.scheduler;
 import java.io.File;
 import java.text.MessageFormat;
 import jp.minecraftuser.ecoframework.PluginFrame;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 /**
@@ -26,14 +27,14 @@ public class ForumSchedulerEventKick extends ForumSchedulerEvent{
         }
         
         // 全ユーザのKICK処理
-        if (params.length >= 2) {
-            if (plg.getPluginFrame("EcoAdmin") != null) {
-                plg.getServer().dispatchCommand(plg.getServer().getConsoleSender(), "ecoadmin:lock "+params[1]);
-            }
-        }
-        MessageFormat mf = new MessageFormat("{0}のためサーバから切断されました。しばらくお待ちください。");
-        for (Player p: plg.getServer().getOnlinePlayers()) {
-            p.kickPlayer(mf.format(new String[]{params[0]}));
+        if (params.length >= 2 && plg.getPluginFrame("EcoAdmin") != null) {
+            //EcoAdmin側でkickする。
+            //メッセージの引数を渡してるけど、kickメッセージはMysqlPlayerDataBridgeのsaveAndKickCommandが表示されます。
+            //引数を渡さない場合ロックされません。
+            plg.getServer().dispatchCommand(plg.getServer().getConsoleSender(), "ecoadmin:lock "+params[1]);
+        }else{
+            String command = "mpdb saveAndkick";
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
         }
     }
 }


### PR DESCRIPTION
EcoAdminのlock処理でkickする際に、MysqlPlayerDataBridgeのsaveAndkickを呼び出しています。
MysqlPlayerDataBridgeが万が一読み込まれてないとkickされなくなるので、
依存関係に入れてプラグインが存在していればメソッド叩くほうがいいかも?