### PR TITLE
entコマンドの複数サーバー対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>Setuden</artifactId>
-    <version>0.20</version>
+    <version>0.21</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>Setuden</artifactId>
-    <version>0.19</version>
+    <version>0.20</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/setuden/Setuden.java
+++ b/src/main/java/jp/minecraftuser/setuden/Setuden.java
@@ -6,27 +6,14 @@ import java.util.logging.Level;
 import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.CommandFrame;
 import jp.minecraftuser.ecoframework.ConfigFrame;
-import jp.minecraftuser.setuden.command.EntCommand;
-import jp.minecraftuser.setuden.command.PlzombieCommand;
-import jp.minecraftuser.setuden.command.SetmsgCommand;
-import jp.minecraftuser.setuden.command.TestCommand;
-import jp.minecraftuser.setuden.command.SetudenCommand;
-import jp.minecraftuser.setuden.command.SetudenMkbaseCommand;
-import jp.minecraftuser.setuden.command.SetudenMkbaseendCommand;
-import jp.minecraftuser.setuden.command.SetudenPermissionCommand;
-import jp.minecraftuser.setuden.command.SetudenPermissionSetCommand;
-import jp.minecraftuser.setuden.command.SetudenPermissionUnsetCommand;
-import jp.minecraftuser.setuden.command.SetudenReloadCommand;
-import jp.minecraftuser.setuden.command.WhoisCommand;
+import jp.minecraftuser.setuden.command.*;
 import jp.minecraftuser.setuden.config.SetudenConfig;
 import jp.minecraftuser.setuden.config.PluginConfigUpdate;
 import jp.minecraftuser.setuden.config.SetudenPermissionConfig;
 import jp.minecraftuser.setuden.db.WhoisDB;
-import jp.minecraftuser.setuden.listener.DeathListener;
-import jp.minecraftuser.setuden.listener.GuardListener;
-import jp.minecraftuser.setuden.listener.PlayerListener;
-import jp.minecraftuser.setuden.listener.TestListener;
+import jp.minecraftuser.setuden.listener.*;
 import jp.minecraftuser.setuden.scheduler.ForumScheduler;
+import org.bukkit.Bukkit;
 
 /**
  *
@@ -34,12 +21,18 @@ import jp.minecraftuser.setuden.scheduler.ForumScheduler;
  */
 public class Setuden  extends PluginFrame {
 
+    public static Setuden instance;
+
+    public static String OUTGOING_PLUGIN_CHANNEL = "bsuite:warps-in";
+    public static String INCOMING_PLUGIN_CHANNEL = "bsuite:warps-out";
     /**
      * プラグイン開始処理
      */
     @Override
     public void onEnable() {
         initialize();
+        registerChannels();
+        instance = this;
     }
 
     /**
@@ -94,6 +87,8 @@ public class Setuden  extends PluginFrame {
         registerPluginCommand(new SetmsgCommand(this, "setmsg"));
         registerPluginCommand(new EntCommand(this, "ent"));
         registerPluginCommand(new EntCommand(this, "entrance"));
+        registerPluginCommand(new SetEntCommand(this, "setent"));
+        registerPluginCommand(new SetEntCommand(this, "setentrance"));
         registerPluginCommand(new PlzombieCommand(this, "plzombie"));
         registerPluginCommand(new TestCommand(this, "test"));
     }
@@ -107,8 +102,15 @@ public class Setuden  extends PluginFrame {
         registerPluginListener(new DeathListener(this, "death"));
         registerPluginListener(new GuardListener(this, "guard"));
         registerPluginListener(new TestListener(this, "test"));
+        registerPluginListener(new WarpListener(this, "warp"));
     }
 
+    private void registerChannels() {
+        Bukkit.getMessenger().registerIncomingPluginChannel(this,
+                INCOMING_PLUGIN_CHANNEL, new WarpMessageListener());
+        Bukkit.getMessenger().registerOutgoingPluginChannel(this,
+                OUTGOING_PLUGIN_CHANNEL);
+    }
     /**
      * タイマー処理の初期化と登録
      */

--- a/src/main/java/jp/minecraftuser/setuden/command/SetEntCommand.java
+++ b/src/main/java/jp/minecraftuser/setuden/command/SetEntCommand.java
@@ -13,7 +13,7 @@ import org.bukkit.entity.Player;
  *
  * @author ecolight
  */
-public class EntCommand extends CommandFrame {
+public class SetEntCommand extends CommandFrame {
     private static SetudenConfig ecaConf = null;
 
     /**
@@ -22,7 +22,7 @@ public class EntCommand extends CommandFrame {
      * @param plg_  プラグインインスタンス
      * @param name_ コマンド名
      */
-    public EntCommand(PluginFrame plg_, String name_) {
+    public SetEntCommand(PluginFrame plg_, String name_) {
         super(plg_, name_);
         ecaConf = (SetudenConfig) conf;
     }
@@ -34,7 +34,7 @@ public class EntCommand extends CommandFrame {
      */
     @Override
     public String getPermissionString() {
-        return "setuden.entrance";
+        return "setuden.setentrance";
     }
 
     /**
@@ -46,10 +46,14 @@ public class EntCommand extends CommandFrame {
      */
     @Override
     public boolean worker(CommandSender sender, String[] args) {
+        // ワールド指定でイベント中なら該当ワールド以外は有効とする
         Player player = (Player) sender;
+
         if (player != null) {
-            WarpManager.sendWarpPlayer(player, player.getName(), "entrance", true, false);
+            WarpManager.sendSetWarp(player, "entrance", player.getLocation(), false, true);
             return true;
+
+
         }
         return true;
     }

--- a/src/main/java/jp/minecraftuser/setuden/db/WhoisDB.java
+++ b/src/main/java/jp/minecraftuser/setuden/db/WhoisDB.java
@@ -217,7 +217,7 @@ public class WhoisDB extends DatabaseFrame {
         } else {
             long total_play_second = player.getStatistic(Statistic.TOTAL_WORLD_TIME) / 20;
             long play_day = total_play_second / 86400;
-            long play_hour = total_play_second / 3600;
+            long play_hour = total_play_second % 3600;
             long play_minute = (total_play_second % 3600) / 60;
             long play_second = total_play_second % 60;
             StringBuilder b = new StringBuilder();

--- a/src/main/java/jp/minecraftuser/setuden/listener/WarpListener.java
+++ b/src/main/java/jp/minecraftuser/setuden/listener/WarpListener.java
@@ -1,0 +1,30 @@
+package jp.minecraftuser.setuden.listener;
+
+import jp.minecraftuser.ecoframework.ListenerFrame;
+import jp.minecraftuser.ecoframework.PluginFrame;
+import jp.minecraftuser.setuden.managers.WarpManager;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerJoinEvent;
+/**
+ * プレイヤー接続イベント処理リスナークラス
+ * @author ecolight
+ */
+public class WarpListener extends ListenerFrame {
+
+    public WarpListener(PluginFrame plg_, String name_) {
+        super(plg_, name_);
+
+    }
+
+    //プレイヤー接続の際に、テレポートが保留状態であれば、テレポートする
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void playerConnect(PlayerJoinEvent e) {
+        if (WarpManager.pendingTeleports.containsKey(e.getPlayer().getName())) {
+            Location l = WarpManager.pendingTeleports.get(e.getPlayer().getName());
+            e.getPlayer().teleport(l);
+        }
+    }
+
+}

--- a/src/main/java/jp/minecraftuser/setuden/listener/WarpMessageListener.java
+++ b/src/main/java/jp/minecraftuser/setuden/listener/WarpMessageListener.java
@@ -1,0 +1,53 @@
+package jp.minecraftuser.setuden.listener;
+
+
+import jp.minecraftuser.setuden.Setuden;
+import jp.minecraftuser.setuden.managers.WarpManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+public class WarpMessageListener implements PluginMessageListener {
+
+    /**
+     * プラグインメッセージ処理リスナークラス
+     * @author ecolight
+     */
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(message));
+        String task = null;
+        try {
+            task = in.readUTF();
+
+            if (task.equals("TeleportPlayerToLocation")) {
+                //受信したメッセージを元にプレイヤーを指定の座標にテレポートする
+                WarpManager.warpPlayerToLocation(in.readUTF(), new Location(Bukkit.getWorld(in.readUTF()), in.readDouble(), in.readDouble(), in.readDouble(), in.readFloat(), in.readFloat()));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (task.equals("GetVersion")) {
+            String name = null;
+            try {
+                name = in.readUTF();
+            } catch (IOException e) {
+
+            }
+            if (name != null) {
+                Player p = Bukkit.getPlayer(name);
+
+                p.sendMessage(ChatColor.RED + "warps - " + ChatColor.GOLD + Setuden.instance.getDescription().getVersion());
+            }
+            WarpManager.sendVersion();
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "warps - " + ChatColor.GOLD + Setuden.instance.getDescription().getVersion());
+        }
+
+    }
+}

--- a/src/main/java/jp/minecraftuser/setuden/managers/WarpManager.java
+++ b/src/main/java/jp/minecraftuser/setuden/managers/WarpManager.java
@@ -1,0 +1,95 @@
+package jp.minecraftuser.setuden.managers;
+
+import jp.minecraftuser.setuden.Setuden;
+import jp.minecraftuser.setuden.tasks.PluginMessageTask;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class WarpManager {
+
+    public static HashMap<String, Location> pendingTeleports = new HashMap<>();
+
+    //ワープ座標の設定を送信するメソッド
+    //globalがtrueなら別鯖からでもアクセスできる
+    public static void sendSetWarp(CommandSender sender, String warp_name, Location loc, boolean hidden, boolean global) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(b);
+        try {
+            out.writeUTF("SetWarp");
+            out.writeUTF(sender.getName());
+            out.writeUTF(warp_name);
+            out.writeUTF(loc.getWorld().getName());
+            out.writeDouble(loc.getX());
+            out.writeDouble(loc.getY());
+            out.writeDouble(loc.getZ());
+            out.writeFloat(loc.getYaw());
+            out.writeFloat(loc.getPitch());
+            out.writeBoolean(hidden);
+            out.writeBoolean(global);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        new PluginMessageTask(b).runTaskAsynchronously(Setuden.instance);
+
+    }
+
+    //ワープへの移動を送信するメソッド
+    public static void sendWarpPlayer(CommandSender sender, String warp_player, String warp_name, boolean permission, boolean bypass) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(b);
+        try {
+            out.writeUTF("WarpPlayer");
+            out.writeUTF(sender.getName());
+            out.writeUTF(warp_player);
+            out.writeUTF(warp_name);
+            out.writeBoolean(permission);
+            out.writeBoolean(bypass);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        new PluginMessageTask(b).runTaskAsynchronously(Setuden.instance);
+    }
+
+    //受信した座標にテレポートするメソッド
+    public static void warpPlayerToLocation(final String player, Location location) {
+        Player p = Bukkit.getPlayer(player);
+        if (p != null) {
+            //既にプレイヤーが入ればテレポート
+            p.teleport(location);
+        } else {
+            //まだプレイヤーのログインが終わっていない場合は保留リストに追加
+            pendingTeleports.put(player, location);
+
+            //100経過後に保留リストから削除
+            Bukkit.getScheduler().runTaskLaterAsynchronously(Setuden.instance, new Runnable() {
+                @Override
+                public void run() {
+                    if (pendingTeleports.containsKey(player)) {
+                        pendingTeleports.remove(player);
+                    }
+                }
+            }, 100);
+        }
+    }
+
+    public static void sendVersion() {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(b);
+        try {
+            out.writeUTF("sendversion");
+            out.writeUTF(ChatColor.RED + "warps - " + ChatColor.GOLD + Setuden.instance.getDescription().getVersion());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        new PluginMessageTask(b).runTaskAsynchronously(Setuden.instance);
+    }
+}

--- a/src/main/java/jp/minecraftuser/setuden/tasks/PluginMessageTask.java
+++ b/src/main/java/jp/minecraftuser/setuden/tasks/PluginMessageTask.java
@@ -1,0 +1,36 @@
+package jp.minecraftuser.setuden.tasks;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import jp.minecraftuser.setuden.Setuden;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class PluginMessageTask extends BukkitRunnable {
+
+	private final ByteArrayOutputStream bytes;
+
+	public PluginMessageTask(ByteArrayOutputStream bytes) {
+		this.bytes = bytes;
+	}
+	
+	public void run() {
+		getOnlinePlayers().get(0).sendPluginMessage(
+				Setuden.instance,
+				Setuden.OUTGOING_PLUGIN_CHANNEL,
+				bytes.toByteArray());
+		
+	}
+	
+	public static List<Player> getOnlinePlayers() {
+		List<Player> players = new ArrayList<>();
+		for (Player all : Bukkit.getOnlinePlayers()) {
+			players.add(all);
+		}
+		return players;
+	}
+		
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -49,6 +49,14 @@ commands:
     description: Setuden command.
     usage: /<command>
     permission: setuden.entrance
+  setent:
+    description: Setuden command.
+    usage: /<command>
+    permission: setuden.setentrance
+  setentrance:
+    description: Setuden command.
+    usage: /<command>
+    permission: setuden.setentrance
   plzombie:
     description: Setuden command.
     usage: /<command>


### PR DESCRIPTION
entコマンドの複数サーバー対応
BungeeSuiteのワープ機能を利用しています。

いままでは/entの座標はソースコード内で設定していましたが
/setentコマンド追加し、コマンド入力時のプレイヤーの座標を/entの地点に設定します。

また、/entコマンドはエントランスワールドでも使えるよう変更しました。